### PR TITLE
Add choosing of mode for troubleshooting from Main window

### DIFF
--- a/src/pages/Main/Main.py
+++ b/src/pages/Main/Main.py
@@ -176,6 +176,7 @@ class Main(Tk):
                 self.settings,
                 self.screen_size,
                 self.light,
+                sel_acc.get(),
                 self.refresh,
             ),
         ).grid(row=0, column=2, padx=5, pady=3, sticky=S)

--- a/src/pages/Main/utils/routes.py
+++ b/src/pages/Main/utils/routes.py
@@ -118,12 +118,12 @@ def show_accuracy(settings, screen_size, light, mat):
             light.light_switch()
 
 
-def show_settings(self, settings, screen_size, light, refresh):
+def show_settings(self, settings, screen_size, light, mode, refresh):
     """Show Settings Page"""
     try:
         login, superuser = Login(settings, screen_size).res
         if login:
-            res = Settings(light, superuser).res
+            res = Settings(mode, light, superuser).res
             if res:
                 self.light.close()
                 self.destroy()

--- a/src/pages/Settings/Settings.py
+++ b/src/pages/Settings/Settings.py
@@ -26,15 +26,15 @@ from utils.read_write import read_settings
 
 
 class Settings(Toplevel):
-    def __init__(self, light, superuser):
+    def __init__(self, mode, light, superuser):
         Toplevel.__init__(self)
-        self.initialize(light)
+        self.initialize(mode, light)
         self.win_config()
         self.widgets(superuser)
         self.grab_set()
         self.mainloop()
 
-    def initialize(self, light):
+    def initialize(self, mode, light):
         self.res = False
         settings = read_settings()
         self.set_names = settings["Names"]
@@ -45,7 +45,7 @@ class Settings(Toplevel):
         self.light = light
         self.troubleshoot = self.set_set["Troubleshoot"]
         if self.troubleshoot["Trouble"]:
-            file_lists = os.listdir(dire.path_trouble)
+            file_lists = [file for file in os.listdir(dire.path_trouble) if mode in file]
             file_name = (
                 random.sample(file_lists, 1)[0]
                 if self.troubleshoot["File Name"] == ""


### PR DESCRIPTION
# Description

> Please include a summary of the changes and the related issue. Please also include relevant motivation and context. List any dependencies that are required for this change.

Troubleshoot image is using at random from trouble folder when starting settings page

## Fixes / issues

Amend to allow choosing of mode for troubleshoot image to show when starting settings page.

## Type of change

> Please delete options that are not relevant.

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist before requesting a review
- [x] I have performed a self-review of my code
- [ ] If it is a core feature, I have added thorough tests.
- [ ] Do we need to implement analytics?
- [ ] Will this be part of a product update? If yes, please write one phrase about this update.