### PR TITLE
convert cali_pixel to float

### DIFF
--- a/src/Utils/features.py
+++ b/src/Utils/features.py
@@ -135,6 +135,7 @@ def get_defect_area(img, col_dict, cali_pixel, contours):
     defects = {}
     blur = cv2.GaussianBlur(img.copy(), (5, 5), 0)
     hsv = cv2.cvtColor(blur, cv2.COLOR_BGR2HSV_FULL)
+    cali_pixel = float(cali_pixel) #convert cali_pixel to float
     for cnt in contours:
         cArea = cv2.contourArea(cnt)
         if 1000000 < cArea or cArea < 50:


### PR DESCRIPTION
# Description

> Please include a summary of the changes and the related issue. Please also include relevant motivation and context. List any dependencies that are required for this change.

error in get defect area calculation due to different data type .
cali_pixel is str data type while cArea is float data type. 

## Fixes / issues

cali_pixel convert to float data type 

## Type of change

> Please delete options that are not relevant.

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist before requesting a review
- [x] I have performed a self-review of my code
- [ ] If it is a core feature, I have added thorough tests.
- [ ] Do we need to implement analytics?
- [ ] Will this be part of a product update? If yes, please write one phrase about this update.